### PR TITLE
Show availability when returning status

### DIFF
--- a/lib/chef/knife/pushy_node_status.rb
+++ b/lib/chef/knife/pushy_node_status.rb
@@ -7,7 +7,7 @@ class Chef
         rest = Chef::REST.new(Chef::Config[:chef_server_url])
 
         get_node_statuses(name_args).each do |node_status|
-          puts "#{node_status['node_name']}\t#{node_status['status']}\t#{node_status['updated_at']}"
+          puts "#{node_status['node_name']}\t#{node_status['availability']}"
         end
       end
 


### PR DESCRIPTION
Since returned nodes will always be up, the nodes availability is more
important

https://github.com/opscode/opscode-pushy-server/pull/55
