### PR TITLE
Handle multiple job listing better

### DIFF
--- a/lib/chef/knife/pushy_job_list.rb
+++ b/lib/chef/knife/pushy_job_list.rb
@@ -7,8 +7,12 @@ class Chef
         rest = Chef::REST.new(Chef::Config[:chef_server_url])
 
         jobs = rest.get_rest("pushy/jobs")
-        output(jobs)
+        output(as_map(jobs))
       end
+    end
+
+    def as_map(jobs)
+       jobs.inject({}) { |map, job| map[job['id']] =job;map}
     end
   end
 end

--- a/lib/chef/knife/pushy_job_status.rb
+++ b/lib/chef/knife/pushy_job_status.rb
@@ -8,7 +8,15 @@ class Chef
 
         job_id = name_args[0]
         job = rest.get_rest("pushy/jobs/#{job_id}")
-        output(job)
+        if job.kind_of?(Array) # list of jobs
+          output(as_map(job))
+        else
+          output(job)
+        end
+      end
+
+      def as_map(jobs)
+        jobs.inject({}) { |map, job| map[job['id']] =job;map}
       end
     end
   end


### PR DESCRIPTION
Convert a list of multiple jobs to a map of job_id -> job so that they get
displayed better by the output formatter
