### PR TITLE
fix the attribute search uses for job start to node name

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -39,7 +39,7 @@ class Chef
             ui.error("knife search failed: #{msg}")
             exit 1
           end
-          nodes.each { |node| @node_names << node[:hostname] unless node[:hostname].nil? }
+          nodes.each { |node| @node_names << node[:name] unless node[:name].nil? }
         else
           @node_names = name_args[1,name_args.length-1]
         end


### PR DESCRIPTION
When pull request #14 was merged, Tim was using "hostname" as the attribute for the node list. node.hostname does not always equal node.name which is what is needed to start a push job.
