### PR TITLE
use node names not hostnames in job dispatch

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -56,7 +56,7 @@ class Chef
             ui.error("knife search failed: #{msg}")
             exit 1
           end
-          nodes.each { |node| @node_names << node[:hostname] unless node[:hostname].nil? }
+          nodes.each { |node| @node_names << node.name }
         else
           @node_names = name_args[1,name_args.length-1]
         end


### PR DESCRIPTION
Commit 54ecc0e introduced a bug where the nodes from the search results would be collected by hostname rather than node name. Push jobs are dispatched to nodes by their `Chef::Node` name.
