### PR TITLE
relax Chef gem dependency to be everything above 11.04

### DIFF
--- a/knife-push.gemspec
+++ b/knife-push.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   # can be included with apps that have restrictive Gemfile.locks.
   # s.add_dependency "mixlib-cli", ">= 1.2.2"
 
-  s.add_dependency 'chef', '~> 11.10.4'
+  s.add_dependency 'chef', '>= 11.10.4'
   s.require_path = 'lib'
   s.files = %w(LICENSE README.rdoc Rakefile) + Dir.glob("{lib,spec}/**/*")
 end

--- a/lib/knife-push/version.rb
+++ b/lib/knife-push/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Push
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
The gemspec has a version requirement on 11.10.4 set via "~>". This has a side effect of pulling in the chef 11.10.4 gem when using chef 11.12 or higher. 

This fixes it and bumps the version appropriately. 
