### PR TITLE
Fix nowait option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -44,7 +44,7 @@ The maximum amount of time (in seconds) by which a job must complete, before it 
 The minimum number of nodes that match the search criteria, are available, and acknowledge the job request. This can be expressed as a
 percentage (e.g. 50%) or as an absolute number of nodes (e.g. 145). Default value: 100%
 
-  -b --no-wait
+  -b --nowait
 
 Exit immediately after starting a job instead of waiting for it to complete.
 

--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -44,7 +44,7 @@ class Chef
             :description => 'Solr query for list of job candidates.'
 
       option :nowait,
-        :long => '--no-wait',
+        :long => '--nowait',
         :short => '-b',
         :boolean => true,
         :default => false,


### PR DESCRIPTION
This PR fix --no-wait option so ruby's OptionParser treat no- prefix as false. This is why --no-wait true is treated as nowait false.

https://github.com/chef/knife-push/pull/23
see: http://stderr.org/doc/liboptparse-ruby/optparse.html
```
TrueClass
Boolean switch, which means whether it is present or not, whether it is absent or not with prefix no-, or it takes an argument yes/no/true/false/+/-.
```