### PR TITLE
Make the polling rate configurable for job status

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -50,6 +50,11 @@ class Chef
         :default => false,
         :description => "Rather than waiting for each job to complete, exit immediately after starting the job."
 
+      option :poll_interval,
+             :long => '--poll-interval RATE',
+             :default => 1.0,
+             :description => "Repeat interval for job status update (in seconds)."
+      
       def run
         @node_names = []
 
@@ -95,7 +100,8 @@ class Chef
         exit(0) if config[:nowait]
         previous_state = "Initialized."
         begin
-          sleep(0.1)
+          sleep(config[:poll_interval].to_f)
+          putc(".")
           job = rest.get_rest(job_uri)
           finished, state = status_string(job)
           if state != previous_state


### PR DESCRIPTION
The 0.1 second polling rate is overly intrusive for some users, and can
exacerbate problems on an already loaded server. This sets the default
rate to 1 second and makes it configurable.

@jkeiser If you have a chance, would you take a look at this?