### PR TITLE
Use knife's rest method to ensure compatibility with all chef versions

### DIFF
--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 class Chef
   class Knife
     module JobHelpers

--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -93,7 +93,6 @@ class Chef
       def self.run_helper(config, job_json)
         job_json['run_timeout'] ||= config[:run_timeout].to_i if config[:run_timeout]
 
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
         result = rest.post_rest('pushy/jobs', job_json)
         job_uri = result['uri']
         puts "Started.  Job ID: #{job_uri[-32,32]}"

--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+require 'chef/rest'
 
 class Chef
   class Knife

--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -14,8 +14,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-require 'chef/rest'
-
 class Chef
   class Knife
     module JobHelpers

--- a/lib/chef/knife/job_list.rb
+++ b/lib/chef/knife/job_list.rb
@@ -14,8 +14,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-require 'chef/rest'
-
 class Chef
   class Knife
     class JobList < Chef::Knife

--- a/lib/chef/knife/job_list.rb
+++ b/lib/chef/knife/job_list.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 class Chef
   class Knife
     class JobList < Chef::Knife
@@ -26,5 +27,4 @@ class Chef
     end
   end
 end
-
 

--- a/lib/chef/knife/job_list.rb
+++ b/lib/chef/knife/job_list.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+require 'chef/rest'
 
 class Chef
   class Knife

--- a/lib/chef/knife/job_list.rb
+++ b/lib/chef/knife/job_list.rb
@@ -22,8 +22,6 @@ class Chef
       banner "knife job list"
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         jobs = rest.get_rest("pushy/jobs")
         output(jobs)
       end

--- a/lib/chef/knife/job_output.rb
+++ b/lib/chef/knife/job_output.rb
@@ -14,8 +14,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-require 'chef/rest'
-
 class Chef
   class Knife
     class JobOutput < Chef::Knife

--- a/lib/chef/knife/job_output.rb
+++ b/lib/chef/knife/job_output.rb
@@ -27,8 +27,6 @@ class Chef
              :description => "Which output channel to fetch (default stdout)."
       
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         job_id = name_args[0]
         channel = get_channel(config[:channel])
         node = name_args[1]

--- a/lib/chef/knife/job_output.rb
+++ b/lib/chef/knife/job_output.rb
@@ -24,14 +24,14 @@ class Chef
              :long => '--channel stdout|stderr',
              :default => 'stdout',
              :description => "Which output channel to fetch (default stdout)."
-      
+
       def run
         job_id = name_args[0]
         channel = get_channel(config[:channel])
         node = name_args[1]
 
         uri = "pushy/jobs/#{job_id}/output/#{node}/#{channel}"
-        
+
         job = rest.get_rest(uri, false, {"Accept"=>"application/octet-stream"})
 
         output(job)
@@ -46,9 +46,9 @@ class Chef
           return channel
         else
           raise "Invalid Format please enter stdout or stderr"
-        end        
+        end
       end
-      
+
     end
   end
 end

--- a/lib/chef/knife/job_output.rb
+++ b/lib/chef/knife/job_output.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+require 'chef/rest'
 
 class Chef
   class Knife

--- a/lib/chef/knife/job_output.rb
+++ b/lib/chef/knife/job_output.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 class Chef
   class Knife
     class JobOutput < Chef::Knife

--- a/lib/chef/knife/job_status.rb
+++ b/lib/chef/knife/job_status.rb
@@ -14,8 +14,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-require 'chef/rest'
-
 class Chef
   class Knife
     class JobStatus < Chef::Knife

--- a/lib/chef/knife/job_status.rb
+++ b/lib/chef/knife/job_status.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+require 'chef/rest'
 
 class Chef
   class Knife

--- a/lib/chef/knife/job_status.rb
+++ b/lib/chef/knife/job_status.rb
@@ -22,8 +22,6 @@ class Chef
       banner "knife job status <job id>"
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         job_id = name_args[0]
         job = rest.get_rest("pushy/jobs/#{job_id}")
         output(job)

--- a/lib/chef/knife/node_status.rb
+++ b/lib/chef/knife/node_status.rb
@@ -14,9 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-begin
-  require 'chef/rest'
-end
+require 'chef/rest'
 
 class Chef
   class Knife
@@ -24,8 +22,6 @@ class Chef
       banner "knife node status [<node> <node> ...]"
 
       def run
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
-
         get_node_statuses(name_args).each do |node_status|
           puts "#{node_status['node_name']}\t#{node_status['availability']}"
         end

--- a/lib/chef/knife/node_status.rb
+++ b/lib/chef/knife/node_status.rb
@@ -14,7 +14,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-require 'chef/rest'
+begin
+  require 'chef/rest'
+end
 
 class Chef
   class Knife

--- a/lib/chef/knife/node_status.rb
+++ b/lib/chef/knife/node_status.rb
@@ -14,8 +14,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-require 'chef/rest'
-
 class Chef
   class Knife
     class NodeStatus < Chef::Knife

--- a/lib/chef/knife/node_status.rb
+++ b/lib/chef/knife/node_status.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+require 'chef/rest'
 
 class Chef
   class Knife

--- a/lib/chef/knife/node_status.rb
+++ b/lib/chef/knife/node_status.rb
@@ -14,6 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 class Chef
   class Knife
     class NodeStatus < Chef::Knife


### PR DESCRIPTION
This changed in Chef 12.7 due to an API deprecation

Resolves #34