### PR TITLE
Mix in JobHelpers directly

### DIFF
--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -18,7 +18,7 @@
 class Chef
   class Knife
     module JobHelpers
-      def self.process_search(search, nodes)
+      def process_search(search, nodes)
         node_names = []
         if search
           q = Chef::Search::Query.new
@@ -44,7 +44,7 @@ class Chef
         return node_names
       end
 
-      def self.status_string(job)
+      def status_string(job)
         case job['status']
         when 'new'
           [false, 'Initialized.']
@@ -64,7 +64,7 @@ class Chef
         end
       end
 
-      def self.get_quorum(quorum, total_nodes)
+      def get_quorum(quorum, total_nodes)
         unless qmatch = /^(\d+)(\%?)$/.match(quorum)
           raise "Invalid Format please enter integer or percent"
         end
@@ -79,7 +79,7 @@ class Chef
         end
       end
 
-      def self.status_code(job)
+      def status_code(job)
         if job['status'] == "complete" && job["nodes"].keys.all? do |key|
             key == "succeeded" || key == "nacked" || key == "unavailable"
           end
@@ -89,7 +89,7 @@ class Chef
         end
       end
 
-      def self.run_helper(config, job_json)
+      def run_helper(config, job_json)
         job_json['run_timeout'] ||= config[:run_timeout].to_i if config[:run_timeout]
 
         result = rest.post_rest('pushy/jobs', job_json)
@@ -110,7 +110,7 @@ class Chef
         job
       end
 
-      def self.file_helper(file_name)
+      def file_helper(file_name)
         if file_name.nil?
           ui.error "No file specified."
           show_usage
@@ -128,7 +128,7 @@ class Chef
         return contents
       end
 
-      def self.get_env(config)
+      def get_env(config)
         env = {}
         begin
           env = config[:with_env] ? JSON.parse(config[:with_env]) : {}

--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -15,9 +15,13 @@
 # under the License.
 #
 
+require 'chef/knife/job_helpers'
+
 class Chef
   class Knife
     class JobStart < Chef::Knife
+
+      include JobHelpers
 
       deps do
         require 'chef/rest'
@@ -89,25 +93,25 @@ class Chef
           exit 1
         end
 
-        @node_names = JobHelpers.process_search(config[:search], name_args[1,@name_args.length-1])
+        @node_names = process_search(config[:search], name_args[1,@name_args.length-1])
 
         job_json = {
           'command' => job_name,
           'nodes' => @node_names,
           'capture_output' => config[:capture_output]
         }
-        job_json['file'] = "raw:" + JobHelpers.file_helper(config[:send_file]) if config[:send_file]
-        job_json['quorum'] = JobHelpers.get_quorum(config[:quorum], @node_names.length)
-        env = JobHelpers.get_env(config)
+        job_json['file'] = "raw:" + file_helper(config[:send_file]) if config[:send_file]
+        job_json['quorum'] = get_quorum(config[:quorum], @node_names.length)
+        env = get_env(config)
         job_json['env'] = env if env
         job_json['dir'] = config[:in_dir] if config[:in_dir]
         job_json['user'] = config[:as_user] if config[:as_user]
 
-        job = JobHelpers.run_helper(config, job_json)
+        job = run_helper(config, job_json)
 
         output(job)
 
-        exit(JobHelpers.status_code(job))
+        exit(status_code(job))
 
       end
 


### PR DESCRIPTION
This fixes https://github.com/chef/knife-push/issues/36

JobHelpers is now included directly into the Chef::Knife::JobStart class.  This allows the functions defined by Knife to be more accessible by the plug-in.

@lamont-granquist @thommay @tyler-ball @chef/client-core