### PR TITLE
Fix undefined method `status_string' error

### DIFF
--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -101,7 +101,7 @@ class Chef
           sleep(config[:poll_interval].to_f)
           putc(".")
           job = rest.get_rest(job_uri)
-          finished, state = JobHelpers.status_string(job)
+          finished, state = status_string(job)
           if state != previous_state
             puts state
             previous_state = state


### PR DESCRIPTION
Ran into this issue today with latest knife-push:

	$ chef exec knife job start hello node1 -VV
	...
	/Users/Scott/.chefdk/gem/ruby/2.1.0/gems/knife-push-1.0.0.pre/lib/chef/knife/job_helpers.rb:104:in `run_helper': undefined method `status_string' for Chef::Knife::JobHelpers:Module (NoMethodError)
    	from /Users/Scott/.chefdk/gem/ruby/2.1.0/gems/knife-push-1.0.0.pre/lib/chef/knife/job_start.rb:110:in `run'
    	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/lib/chef/knife.rb:421:in `block in run_with_pretty_exceptions'
    	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/lib/chef/local_mode.rb:44:in `with_server_connectivity'
    	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/lib/chef/knife.rb:420:in `run_with_pretty_exceptions'
    	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/lib/chef/knife.rb:219:in `run'
    	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/lib/chef/application/knife.rb:148:in `run'
    	from /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.8.1/bin/knife:25:in `<top (required)>'
  	from /opt/chefdk/bin/knife:49:in `load'