### PR TITLE
Update `job output` to use current Knife Rest API

### DIFF
--- a/knife-push.gemspec
+++ b/knife-push.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.name = "knife-push"
   s.version = Knife::Push::VERSION
   s.platform = Gem::Platform::RUBY
-  s.extra_rdoc_files = ["README.md", "CONTRIBUTING.md", "LICENSE" ]
+  s.extra_rdoc_files = ["README.md", "LICENSE" ]
   s.summary = "Knife plugin for Chef push"
   s.description = s.summary
   s.license = "Apache-2.0"

--- a/knife-push.gemspec
+++ b/knife-push.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   # can be included with apps that have restrictive Gemfile.locks.
   # s.add_dependency "mixlib-cli", ">= 1.2.2"
 
-  s.add_dependency "chef", ">= 12.0"
+  s.add_dependency "chef", ">= 12.7.2"
   s.require_path = "lib"
   s.files = %w{LICENSE README.md Rakefile} + Dir.glob("{lib,spec}/**/*")
   s.required_ruby_version = ">= 2.2.2"

--- a/lib/chef/knife/job_output.rb
+++ b/lib/chef/knife/job_output.rb
@@ -32,7 +32,7 @@ class Chef
 
         uri = "pushy/jobs/#{job_id}/output/#{node}/#{channel}"
 
-        job = rest.get_rest(uri, false, { "Accept" => "application/octet-stream" })
+        job = rest.get_rest(uri, { "Accept" => "application/octet-stream" })
 
         output(job)
       end

--- a/lib/knife-push/version.rb
+++ b/lib/knife-push/version.rb
@@ -1,7 +1,7 @@
 
 module Knife
   module Push
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
     MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end


### PR DESCRIPTION
Closes #47, #50, and COOL-513.

Sometime around chef 12.7.2, Chef::Knife moved from using Chef::REST to Chef::ServerAPI, which did not accept a raw value. This release pins the supported versions of Chef to >= 12.7.2 and adheres to the new API.