### PR TITLE
Update job_start.rb

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -24,7 +24,6 @@ class Chef
       include JobHelpers
 
       deps do
-        require "chef/rest"
         require "chef/node"
         require "chef/search/query"
       end


### PR DESCRIPTION
Does not work with ChefDK 2.0.26 due to failed `require` (since `chef/rest` was deprecated / dropped); removing it restores functionality.