### PR TITLE
Chef::Rest is gone in Chef 13

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -24,7 +24,6 @@ class Chef
       include JobHelpers
 
       deps do
-        require "chef/rest"
         require "chef/node"
         require "chef/search/query"
       end
@@ -138,8 +137,6 @@ class Chef
 
         exit(status_code(job))
       end
-
-      private
 
     end
   end


### PR DESCRIPTION
The import wasn't actually needed either
Fixes chef/chef-dk#1337