### PR TITLE
Require Chef 13 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The knife push plugin is used by the Chef workstation to interact with the Push 
 
 ## Requirements
 
-- Chef 12.0 higher
+- Chef 13.0 higher
 - Ruby 2.2.2 or higher
 
 ## Installation:
@@ -158,7 +158,7 @@ For information on contributing to this project see <https://github.com/chef/che
 
 **Author:** John Keiser([jkeiser@chef.io](mailto:jkeiser@chef.io))
 
-**Copyright:** Copyright 2008-2016, Chef Software, Inc.
+**Copyright:** Copyright 2008-2018, Chef Software, Inc.
 
 **License:** Apache License, Version 2.0
 

--- a/knife-push.gemspec
+++ b/knife-push.gemspec
@@ -13,12 +13,7 @@ Gem::Specification.new do |s|
   s.email = "jkeiser@chef.io"
   s.homepage = "https://www.chef.io"
 
-  # We need a more recent version of mixlib-cli in order to support --no- options.
-  # ... but, we can live with those options not working, if it means the plugin
-  # can be included with apps that have restrictive Gemfile.locks.
-  # s.add_dependency "mixlib-cli", ">= 1.2.2"
-
-  s.add_dependency "chef", ">= 12.7.2"
+  s.add_dependency "chef", ">= 13.0"
   s.require_path = "lib"
   s.files = %w{LICENSE README.md Rakefile} + Dir.glob("{lib,spec}/**/*")
   s.required_ruby_version = ">= 2.2.2"


### PR DESCRIPTION
Chef 12 is no longer supported

Signed-off-by: Tim Smith <tsmith@chef.io>