### PR TITLE
Slim the number of files we ship in the gem package

### DIFF
--- a/knife-push.gemspec
+++ b/knife-push.gemspec
@@ -4,17 +4,16 @@ require "knife-push/version"
 Gem::Specification.new do |s|
   s.name = "knife-push"
   s.version = Knife::Push::VERSION
-  s.platform = Gem::Platform::RUBY
   s.extra_rdoc_files = ["README.md", "LICENSE" ]
-  s.summary = "Knife plugin for Chef push"
+  s.summary = "Knife plugin for Chef Push Jobs"
   s.description = s.summary
   s.license = "Apache-2.0"
   s.author = "John Keiser"
   s.email = "jkeiser@chef.io"
-  s.homepage = "https://www.chef.io"
+  s.homepage = "https://github.com/chef/knife-push/"
 
   s.add_dependency "chef", ">= 13.0"
   s.require_path = "lib"
-  s.files = %w{LICENSE README.md Rakefile} + Dir.glob("{lib,spec}/**/*")
+  s.files = %w{LICENSE} + Dir.glob("{lib}/**/*")
   s.required_ruby_version = ">= 2.2.2"
 end


### PR DESCRIPTION
There's no need to ship the readme or rakefile in this repo since there's no specs to actually run in CI.

Signed-off-by: Tim Smith <tsmith@chef.io>