### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -15,7 +15,7 @@
 # under the License.
 #
 
-require "chef/knife/job_helpers"
+require_relative "job_helpers"
 
 class Chef
   class Knife


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>