### PR TITLE
Require Chef Infra 15+ / Ruby 2.5+

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -5,49 +5,12 @@
 set -ue
 
 export USER="root"
-
-echo "--- dependencies"
 export LANG=C.UTF-8 LANGUAGE=C.UTF-8
-S3_URL="s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}"
-
-pull_s3_file() {
-    aws s3 cp "${S3_URL}/$1" "$1" || echo "Could not pull $1 from S3"
-}
-
-push_s3_file() {
-    if [ -f "$1" ]; then
-        aws s3 cp "$1" "${S3_URL}/$1" || echo "Could not push $1 to S3 for caching."
-    fi
-}
-
-apt-get update -y
-apt-get install awscli -y
 
 echo "--- bundle install"
-pull_s3_file "bundle.tar.gz"
-pull_s3_file "bundle.sha256"
-
-if [ -f bundle.tar.gz ]; then
-  tar -xzf bundle.tar.gz
-fi
-
-if [ -n "${RESET_BUNDLE_CACHE:-}" ]; then
-    rm bundle.sha256
-fi
 
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
 
-echo "--- bundle cache"
-if test -f bundle.sha256 && shasum --check bundle.sha256 --status; then
-    echo "Bundled gems have not changed. Skipping upload to s3"
-else
-    echo "Bundled gems have changed. Uploading to s3"
-    shasum -a 256 Gemfile.lock > bundle.sha256
-    tar -czf bundle.tar.gz vendor/
-    push_s3_file bundle.tar.gz
-    push_s3_file bundle.sha256
-fi
-
 echo "+++ bundle exec task"
-bundle exec $1
+bundle exec $@

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,18 +1,15 @@
 ---
 expeditor:
+  cached_folders:
+    - vendor
   defaults:
     buildkite:
+      retry:
+        automatic:
+          limit: 1
       timeout_in_minutes: 30
 
 steps:
-
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
 
 - label: run-lint-and-specs-ruby-2.5
   command:
@@ -40,8 +37,9 @@ steps:
 
 - label: run-specs-windows
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake
+    - bundle config --local path vendor/bundle
+    - bundle install --jobs=7 --retry=3
+    - bundle exec rake spec
   expeditor:
     executor:
       docker:

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ group :test do
   gem "chefstyle"
   gem "rake"
   gem "rspec", "~> 3.0"
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
-    gem "ohai", "<15"
-    gem "chef", "<15"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+    gem "chef-zero", "~> 14.0"
+    gem "chef", "~> 15.0"
   end
 end
 

--- a/knife-push.gemspec
+++ b/knife-push.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.email = "jkeiser@chef.io"
   s.homepage = "https://github.com/chef/knife-push/"
 
-  s.add_dependency "chef", ">= 13.0"
+  s.add_dependency "chef", ">= 15.0"
   s.add_dependency "addressable"
   s.require_path = "lib"
   s.files = %w{LICENSE} + Dir.glob("{lib}/**/*")
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
Remove support for EOL Ruby / Chef releases

Signed-off-by: Tim Smith <tsmith@chef.io>