### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."

--- a/lib/chef/knife/job_helpers.rb
+++ b/lib/chef/knife/job_helpers.rb
@@ -15,7 +15,7 @@
 # under the License.
 #
 
-require "addressable/uri"
+require "addressable/uri" unless defined?(Addressable::URI)
 
 class Chef
   class Knife


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>